### PR TITLE
Remove redundant indexes from FileAudit model

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -25,6 +25,9 @@ class Activity(Base):
     path = mapped_column(Text, nullable=False)
     detail = mapped_column(Text, nullable=False)
 
+    __table_args__ = (Index('idx_activity_repo_timestamp',
+                            'repo_id', 'timestamp'),)
+
     def __init__(self, record):
         super().__init__()
         self.op_type = record['op_type']
@@ -110,11 +113,11 @@ class FileAudit(Base):
     eid = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     timestamp = mapped_column(DateTime, nullable=False, index=True)
     etype = mapped_column(String(length=128), nullable=False)
-    user = mapped_column(String(length=255), nullable=False, index=True)
+    user = mapped_column(String(length=255), nullable=False)
     ip = mapped_column(String(length=45), nullable=False)
     device = mapped_column(Text, nullable=False)
     org_id = mapped_column(Integer, nullable=False)
-    repo_id = mapped_column(String(length=36), nullable=False, index=True)
+    repo_id = mapped_column(String(length=36), nullable=False)
     file_path = mapped_column(Text, nullable=False)
     __table_args__ = (Index('idx_file_audit_orgid_eid',
                             'org_id', 'eid'),
@@ -259,6 +262,8 @@ class FileTrash(Base):
     commit_id = mapped_column(String(length=40))
     path = mapped_column(Text, nullable=False)
     size = mapped_column(BigInteger, nullable=False)
+    __table_args__ = (Index('idx_filetrash_repo_delete_time',
+                            'repo_id', 'delete_time'),)
 
     def __init__(self, record):
         super().__init__()

--- a/mysql.sql
+++ b/mysql.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS `Activity` (
   `path` text NOT NULL,
   `detail` text NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `ix_Activity_timestamp` (`timestamp`)
+  KEY `ix_Activity_timestamp` (`timestamp`),
+  KEY `idx_activity_repo_timestamp` (`repo_id`, `timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `UserActivity` (
@@ -71,11 +72,9 @@ CREATE TABLE IF NOT EXISTS `FileAudit` (
   `repo_id` varchar(36) NOT NULL,
   `file_path` text NOT NULL,
   PRIMARY KEY (`eid`),
-  KEY `ix_FileAudit_user` (`user`),
   KEY `idx_file_audit_user_orgid_eid` (`user`,`org_id`,`eid`),
   KEY `idx_file_audit_repo_org_eid` (`repo_id`,`org_id`,`eid`),
-  KEY `ix_FileAudit_timestamp` (`timestamp`),
-  KEY `ix_FileAudit_repo_id` (`repo_id`)
+  KEY `ix_FileAudit_timestamp` (`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `FileUpdate` (

--- a/mysql.sql
+++ b/mysql.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS `FileHistory` (
   `old_path` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `ix_FileHistory_file_uuid` (`file_uuid`),
+  KEY `ix_FileHistory_repo_id_path_md5` (`repo_id_path_md5`),
   KEY `ix_FileHistory_timestamp` (`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -74,6 +75,7 @@ CREATE TABLE IF NOT EXISTS `FileAudit` (
   PRIMARY KEY (`eid`),
   KEY `idx_file_audit_user_orgid_eid` (`user`,`org_id`,`eid`),
   KEY `idx_file_audit_repo_org_eid` (`repo_id`,`org_id`,`eid`),
+  KEY `idx_file_audit_orgid_eid` (`org_id`,`eid`),
   KEY `ix_FileAudit_timestamp` (`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -87,6 +89,7 @@ CREATE TABLE IF NOT EXISTS `FileUpdate` (
   `file_oper` text NOT NULL,
   PRIMARY KEY (`eid`),
   KEY `idx_file_update_user_orgid_eid` (`user`,`org_id`,`eid`),
+  KEY `idx_file_update_orgid_eid` (`org_id`,`eid`),
   KEY `ix_FileUpdate_timestamp` (`timestamp`),
   KEY `idx_file_update_repo_org_eid` (`repo_id`,`org_id`,`eid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -103,6 +106,8 @@ CREATE TABLE IF NOT EXISTS `PermAudit` (
   `permission` varchar(15) NOT NULL,
   PRIMARY KEY (`eid`),
   KEY `idx_perm_audit_repo_org_eid` (`repo_id`,`org_id`,`eid`),
+  KEY `idx_perm_audit_orgid_eid` (`org_id`,`eid`),
+  KEY `ix_perm_audit_timestamp` (`timestamp`),
   KEY `idx_perm_audit_user_orgid_eid` (`from_user`,`org_id`,`eid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -122,7 +127,7 @@ CREATE TABLE IF NOT EXISTS `FileOpsStat` (
   `number` int(11) NOT NULL,
   `org_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_file_ops_time_org` (`timestamp`,`org_id`)
+  KEY `idx_file_ops_org_time` (`org_id`,`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `UserActivityStat` (
@@ -199,6 +204,7 @@ CREATE TABLE IF NOT EXISTS `VirusFile` (
   `has_deleted` tinyint(1) NOT NULL,
   `has_ignored` tinyint(1) NOT NULL,
   PRIMARY KEY (`vid`),
+  KEY `ix_VirusFile_repo_id` (`repo_id`),
   KEY `ix_VirusFile_has_ignored` (`has_ignored`),
   KEY `ix_VirusFile_has_deleted` (`has_deleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Remove redundant ix_FileAudit_user and ix_FileAudit_repo_id from mysql.sql

Add composite index (repo_id, delete_time) on FileTrash for faster trash queries

Update models.py

Add composite index (repo_id, timestamp) for Activity table

Add idx_activity_repo_timestamp to Activity table in mysql.sql